### PR TITLE
Modifying the json parser so as not to escape unicode characters over u00FF

### DIFF
--- a/json_eep.erl
+++ b/json_eep.erl
@@ -287,5 +287,8 @@ tests(binary) ->
 
     % json object in a json array
     {[-123, <<"foo">>, {[{<<"bar">>, []}]}, null],
-     "[-123,\"foo\",{\"bar\":[]},null]"}
+     "[-123,\"foo\",{\"bar\":[]},null]"},
+
+    % unicode > 256
+    {[<<"ellipsis: \\u2026">>], "[\"ellipsis: \\u2026\"]"}
   ].

--- a/json_lex2.erl
+++ b/json_lex2.erl
@@ -1,3 +1,4 @@
+-file("/usr/local/lib/erlang/lib/parsetools-2.0.9/include/leexinc.hrl", 0).
 %% The source of this file is part of leex distribution, as such it
 %% has the same Copyright as the other files in the leex
 %% distribution. The Copyright is defined in the accompanying file
@@ -11,6 +12,7 @@
 -export([format_error/1]).
 
 %% User code. This is placed here to allow extra attributes.
+-file("./json_lex2.xrl", 32).
 % "
 
 -define(LOG(Name, Value), 
@@ -40,7 +42,12 @@ unescape([$\\,$u,C0,C1,C2,C3|Cs]) ->
 	(dehex(C2) bsl 4) bor
 	(dehex(C1) bsl 8) bor
 	(dehex(C0) bsl 12),
-    [C|unescape(Cs)];
+    case C > 255 of
+        true ->
+            [$\\, $u, C0, C1, C2, C3 |unescape(Cs)];
+        false ->
+            [C|unescape(Cs)]
+    end;
 unescape([C|Cs]) -> [C|unescape(Cs)];
 unescape([]) -> [].
 
@@ -51,6 +58,8 @@ dehex(C) when C >= $A, C =< $F -> C - $A + 10.
 parse_string(StringChars) -> 
     unescape(StringChars).
 
+-file("/usr/local/lib/erlang/lib/parsetools-2.0.9/include/leexinc.hrl", 14).
+
 format_error({illegal,S}) -> ["illegal characters ",io_lib:write_string(S)];
 format_error({user,S}) -> S.
 
@@ -59,174 +68,240 @@ string(String) -> string(String, 1).
 string(String, Line) -> string(String, Line, String, []).
 
 %% string(InChars, Line, TokenChars, Tokens) ->
-%%    {ok,Tokens,Line} | {error,ErrorInfo,Line}.
+%% {ok,Tokens,Line} | {error,ErrorInfo,Line}.
+%% Note the line number going into yystate, L0, is line of token
+%% start while line number returned is line of token end. We want line
+%% of token start.
 
-string([], L, [], Ts) ->			%No partial tokens!
+string([], L, [], Ts) ->                     % No partial tokens!
     {ok,yyrev(Ts),L};
 string(Ics0, L0, Tcs, Ts) ->
     case yystate(yystate(), Ics0, L0, 0, reject, 0) of
-	{A,Alen,Ics1,L1} ->			%Accepting end state
-	    string_cont(Ics1, L1, yyaction(A, Alen, Tcs, L1), Ts);
-	{A,Alen,Ics1,L1,_S1} ->			%After an accepting state
-	    string_cont(Ics1, L1, yyaction(A, Alen, Tcs, L1), Ts);
-	{reject,_Alen,Clen,_Ics1,L1,_S1} ->	%After a non-accepting state
-	    {error,{L1,?MODULE,{illegal,yypre(Tcs, Clen+1)}},L1};
-	{A,Alen,_Clen,_Ics1,L1,_S1} ->
-	    string_cont(yysuf(Tcs, Alen), L1, yyaction(A, Alen, Tcs, L1), Ts)
+        {A,Alen,Ics1,L1} ->                  % Accepting end state
+            string_cont(Ics1, L1, yyaction(A, Alen, Tcs, L0), Ts);
+        {A,Alen,Ics1,L1,_S1} ->              % Accepting transistion state
+            string_cont(Ics1, L1, yyaction(A, Alen, Tcs, L0), Ts);
+        {reject,_Alen,Tlen,_Ics1,L1,_S1} ->  % After a non-accepting state
+            {error,{L0,?MODULE,{illegal,yypre(Tcs, Tlen+1)}},L1};
+        {A,Alen,_Tlen,_Ics1,L1,_S1} ->
+            string_cont(yysuf(Tcs, Alen), L1, yyaction(A, Alen, Tcs, L0), Ts)
     end.
 
 %% string_cont(RestChars, Line, Token, Tokens)
-%%  Test for and remove the end token wrapper.
+%% Test for and remove the end token wrapper. Push back characters
+%% are prepended to RestChars.
 
 string_cont(Rest, Line, {token,T}, Ts) ->
     string(Rest, Line, Rest, [T|Ts]);
+string_cont(Rest, Line, {token,T,Push}, Ts) ->
+    NewRest = Push ++ Rest,
+    string(NewRest, Line, NewRest, [T|Ts]);
 string_cont(Rest, Line, {end_token,T}, Ts) ->
     string(Rest, Line, Rest, [T|Ts]);
+string_cont(Rest, Line, {end_token,T,Push}, Ts) ->
+    NewRest = Push ++ Rest,
+    string(NewRest, Line, NewRest, [T|Ts]);
 string_cont(Rest, Line, skip_token, Ts) ->
     string(Rest, Line, Rest, Ts);
+string_cont(Rest, Line, {skip_token,Push}, Ts) ->
+    NewRest = Push ++ Rest,
+    string(NewRest, Line, NewRest, Ts);
 string_cont(_Rest, Line, {error,S}, _Ts) ->
     {error,{Line,?MODULE,{user,S}},Line}.
 
+%% token(Continuation, Chars) ->
 %% token(Continuation, Chars, Line) ->
-%%    {more,Continuation} | {done,ReturnVal,RestChars}.
+%% {more,Continuation} | {done,ReturnVal,RestChars}.
 %% Must be careful when re-entering to append the latest characters to the
-%% after characters in an accept.
+%% after characters in an accept. The continuation is:
+%% {token,State,CurrLine,TokenChars,TokenLen,TokenLine,AccAction,AccLen}
 
 token(Cont, Chars) -> token(Cont, Chars, 1).
 
 token([], Chars, Line) ->
-    token(Chars, Line, yystate(), Chars, 0, reject, 0);
-token({token,Line,State,Tcs,Clen,Action,Alen}, Chars, _) ->
-    token(Chars, Line, State, Tcs ++ Chars, Clen, Action, Alen).
+    token(yystate(), Chars, Line, Chars, 0, Line, reject, 0);
+token({token,State,Line,Tcs,Tlen,Tline,Action,Alen}, Chars, _) ->
+    token(State, Chars, Line, Tcs ++ Chars, Tlen, Tline, Action, Alen).
 
-%% token(InChars, Line, State, TokenChars, CurrTokLen,
-%%       AcceptAction, AcceptLen) ->
-%%    {more,Continuation} | {done,ReturnVal,RestChars}.
+%% token(State, InChars, Line, TokenChars, TokenLen, TokenLine,
+%% AcceptAction, AcceptLen) ->
+%% {more,Continuation} | {done,ReturnVal,RestChars}.
+%% The argument order is chosen to be more efficient.
 
-token(Ics0, L0, S0, Tcs, Clen0, A0, Alen0) ->
-    case yystate(S0, Ics0, L0, Clen0, A0, Alen0) of
-	{A1,Alen1,Ics1,L1} ->			%Accepting end state
-	    token_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, L1));
-	{A1,Alen1,[],L1,S1} ->			%After an accepting state
-	    {more,{token,L1,S1,Tcs,Alen1,A1,Alen1}};
-	{A1,Alen1,Ics1,L1,_S1} ->
-	    token_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, L1));
-	{A1,Alen1,Clen1,[],L1,S1} ->		%After a non-accepting state
-	    {more,{token,L1,S1,Tcs,Clen1,A1,Alen1}};
-	{reject,_Alen1,_Clen1,eof,L1,_S1} ->
-	    {done,{eof,L1},[]};
-	{reject,_Alen1,Clen1,Ics1,L1,_S1} ->
-	    {done,{error,{L1,?MODULE,{illegal,yypre(Tcs, Clen1+1)}},L1},Ics1};
-	{A1,Alen1,_Clen1,_Ics1,L1,_S1} ->
-	    token_cont(yysuf(Tcs, Alen1), L1, yyaction(A1, Alen1, Tcs, L1))
+token(S0, Ics0, L0, Tcs, Tlen0, Tline, A0, Alen0) ->
+    case yystate(S0, Ics0, L0, Tlen0, A0, Alen0) of
+        %% Accepting end state, we have a token.
+        {A1,Alen1,Ics1,L1} ->
+            token_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline));
+        %% Accepting transition state, can take more chars.
+        {A1,Alen1,[],L1,S1} ->                  % Need more chars to check
+            {more,{token,S1,L1,Tcs,Alen1,Tline,A1,Alen1}};
+        {A1,Alen1,Ics1,L1,_S1} ->               % Take what we got
+            token_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline));
+        %% After a non-accepting state, maybe reach accept state later.
+        {A1,Alen1,Tlen1,[],L1,S1} ->            % Need more chars to check
+            {more,{token,S1,L1,Tcs,Tlen1,Tline,A1,Alen1}};
+        {reject,_Alen1,Tlen1,eof,L1,_S1} ->     % No token match
+            %% Check for partial token which is error.
+            Ret = if Tlen1 > 0 -> {error,{Tline,?MODULE,
+                                          %% Skip eof tail in Tcs.
+                                          {illegal,yypre(Tcs, Tlen1)}},L1};
+                     true -> {eof,L1}
+                  end,
+            {done,Ret,eof};
+        {reject,_Alen1,Tlen1,Ics1,L1,_S1} ->    % No token match
+            Error = {Tline,?MODULE,{illegal,yypre(Tcs, Tlen1+1)}},
+            {done,{error,Error,L1},Ics1};
+        {A1,Alen1,_Tlen1,_Ics1,L1,_S1} ->       % Use last accept match
+            token_cont(yysuf(Tcs, Alen1), L1, yyaction(A1, Alen1, Tcs, Tline))
     end.
 
-%% tokens_cont(RestChars, Line, Token)
-%%  If we have a token or error then return done, else if we have a
-%%  skip_token then continue.
+%% token_cont(RestChars, Line, Token)
+%% If we have a token or error then return done, else if we have a
+%% skip_token then continue.
 
 token_cont(Rest, Line, {token,T}) ->
     {done,{ok,T,Line},Rest};
+token_cont(Rest, Line, {token,T,Push}) ->
+    NewRest = Push ++ Rest,
+    {done,{ok,T,Line},NewRest};
 token_cont(Rest, Line, {end_token,T}) ->
     {done,{ok,T,Line},Rest};
+token_cont(Rest, Line, {end_token,T,Push}) ->
+    NewRest = Push ++ Rest,
+    {done,{ok,T,Line},NewRest};
 token_cont(Rest, Line, skip_token) ->
-    token(Rest, Line, yystate(), Rest, 0, reject, 0);
+    token(yystate(), Rest, Line, Rest, 0, Line, reject, 0);
+token_cont(Rest, Line, {skip_token,Push}) ->
+    NewRest = Push ++ Rest,
+    token(yystate(), NewRest, Line, NewRest, 0, Line, reject, 0);
 token_cont(Rest, Line, {error,S}) ->
     {done,{error,{Line,?MODULE,{user,S}},Line},Rest}.
 
 %% tokens(Continuation, Chars, Line) ->
-%%    {more,Continuation} | {done,ReturnVal,RestChars}.
+%% {more,Continuation} | {done,ReturnVal,RestChars}.
 %% Must be careful when re-entering to append the latest characters to the
-%% after characters in an accept.
+%% after characters in an accept. The continuation is:
+%% {tokens,State,CurrLine,TokenChars,TokenLen,TokenLine,Tokens,AccAction,AccLen}
+%% {skip_tokens,State,CurrLine,TokenChars,TokenLen,TokenLine,Error,AccAction,AccLen}
 
 tokens(Cont, Chars) -> tokens(Cont, Chars, 1).
 
 tokens([], Chars, Line) ->
-    tokens(Chars, Line, yystate(), Chars, 0, [], reject, 0);
-tokens({tokens,Line,State,Tcs,Clen,Ts,Action,Alen}, Chars, _) ->
-    tokens(Chars, Line, State, Tcs ++ Chars, Clen, Ts, Action, Alen);
-tokens({skip_tokens,Line,State,Tcs,Clen,Error,Action,Alen}, Chars, _) ->
-    skip_tokens(Chars, Line, State, Tcs ++ Chars, Clen, Error, Action, Alen).
+    tokens(yystate(), Chars, Line, Chars, 0, Line, [], reject, 0);
+tokens({tokens,State,Line,Tcs,Tlen,Tline,Ts,Action,Alen}, Chars, _) ->
+    tokens(State, Chars, Line, Tcs ++ Chars, Tlen, Tline, Ts, Action, Alen);
+tokens({skip_tokens,State,Line,Tcs,Tlen,Tline,Error,Action,Alen}, Chars, _) ->
+    skip_tokens(State, Chars, Line, Tcs ++ Chars, Tlen, Tline, Error, Action, Alen).
 
-%% tokens(InChars, Line, State, TokenChars, CurrTokLen, Tokens,
-%%        AcceptAction, AcceptLen) ->
-%%    {more,Continuation} | {done,ReturnVal,RestChars}.
+%% tokens(State, InChars, Line, TokenChars, TokenLen, TokenLine, Tokens,
+%% AcceptAction, AcceptLen) ->
+%% {more,Continuation} | {done,ReturnVal,RestChars}.
 
-tokens(Ics0, L0, S0, Tcs, Clen0, Ts, A0, Alen0) ->
-    case yystate(S0, Ics0, L0, Clen0, A0, Alen0) of
-	{A1,Alen1,Ics1,L1} ->			%Accepting end state
-	    tokens_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, L1), Ts);
-	{A1,Alen1,[],L1,S1} ->			%After an accepting state
-	    {more,{tokens,L1,S1,Tcs,Alen1,Ts,A1,Alen1}};
-	{A1,Alen1,Ics1,L1,_S1} ->
-	    tokens_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, L1), Ts);
-	{A1,Alen1,Clen1,[],L1,S1} ->		%After a non-accepting state
-	    {more,{tokens,L1,S1,Tcs,Clen1,Ts,A1,Alen1}};
-	{reject,_Alen1,_Clen1,eof,L1,_S1} ->
-	    {done,if Ts == [] -> {eof,L1};
-		     true -> {ok,yyrev(Ts),L1} end,[]};
-	{reject,_Alen1,Clen1,_Ics1,L1,_S1} ->
-	    %% Skip rest of tokens.
-	    skip_tokens(yysuf(Tcs, Clen1+1), L1,
-			{L1,?MODULE,{illegal,yypre(Tcs, Clen1+1)}});
-	{A1,Alen1,_Clen1,_Ics1,L1,_S1} ->
-	    tokens_cont(yysuf(Tcs, Alen1), L1, yyaction(A1, Alen1, Tcs, L1), Ts)
+tokens(S0, Ics0, L0, Tcs, Tlen0, Tline, Ts, A0, Alen0) ->
+    case yystate(S0, Ics0, L0, Tlen0, A0, Alen0) of
+        %% Accepting end state, we have a token.
+        {A1,Alen1,Ics1,L1} ->
+            tokens_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline), Ts);
+        %% Accepting transition state, can take more chars.
+        {A1,Alen1,[],L1,S1} ->                  % Need more chars to check
+            {more,{tokens,S1,L1,Tcs,Alen1,Tline,Ts,A1,Alen1}};
+        {A1,Alen1,Ics1,L1,_S1} ->               % Take what we got
+            tokens_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline), Ts);
+        %% After a non-accepting state, maybe reach accept state later.
+        {A1,Alen1,Tlen1,[],L1,S1} ->            % Need more chars to check
+            {more,{tokens,S1,L1,Tcs,Tlen1,Tline,Ts,A1,Alen1}};
+        {reject,_Alen1,Tlen1,eof,L1,_S1} ->     % No token match
+            %% Check for partial token which is error, no need to skip here.
+            Ret = if Tlen1 > 0 -> {error,{Tline,?MODULE,
+                                          %% Skip eof tail in Tcs.
+                                          {illegal,yypre(Tcs, Tlen1)}},L1};
+                     Ts == [] -> {eof,L1};
+                     true -> {ok,yyrev(Ts),L1}
+                  end,
+            {done,Ret,eof};
+        {reject,_Alen1,Tlen1,_Ics1,L1,_S1} ->
+            %% Skip rest of tokens.
+            Error = {L1,?MODULE,{illegal,yypre(Tcs, Tlen1+1)}},
+            skip_tokens(yysuf(Tcs, Tlen1+1), L1, Error);
+        {A1,Alen1,_Tlen1,_Ics1,L1,_S1} ->
+            Token = yyaction(A1, Alen1, Tcs, Tline),
+            tokens_cont(yysuf(Tcs, Alen1), L1, Token, Ts)
     end.
 
 %% tokens_cont(RestChars, Line, Token, Tokens)
-%%  If we have a end_token or error then return done, else if we have
-%%  a token then save it and continue, else if we have a skip_token
-%%  just continue.
+%% If we have an end_token or error then return done, else if we have
+%% a token then save it and continue, else if we have a skip_token
+%% just continue.
 
 tokens_cont(Rest, Line, {token,T}, Ts) ->
-    tokens(Rest, Line, yystate(), Rest, 0, [T|Ts], reject, 0);
+    tokens(yystate(), Rest, Line, Rest, 0, Line, [T|Ts], reject, 0);
+tokens_cont(Rest, Line, {token,T,Push}, Ts) ->
+    NewRest = Push ++ Rest,
+    tokens(yystate(), NewRest, Line, NewRest, 0, Line, [T|Ts], reject, 0);
 tokens_cont(Rest, Line, {end_token,T}, Ts) ->
     {done,{ok,yyrev(Ts, [T]),Line},Rest};
+tokens_cont(Rest, Line, {end_token,T,Push}, Ts) ->
+    NewRest = Push ++ Rest,
+    {done,{ok,yyrev(Ts, [T]),Line},NewRest};
 tokens_cont(Rest, Line, skip_token, Ts) ->
-    tokens(Rest, Line, yystate(), Rest, 0, Ts, reject, 0);
+    tokens(yystate(), Rest, Line, Rest, 0, Line, Ts, reject, 0);
+tokens_cont(Rest, Line, {skip_token,Push}, Ts) ->
+    NewRest = Push ++ Rest,
+    tokens(yystate(), NewRest, Line, NewRest, 0, Line, Ts, reject, 0);
 tokens_cont(Rest, Line, {error,S}, _Ts) ->
     skip_tokens(Rest, Line, {Line,?MODULE,{user,S}}).
 
 %%skip_tokens(InChars, Line, Error) -> {done,{error,Error,Line},Ics}.
-%%  Skip tokens until an end token, junk everything and return the error.
+%% Skip tokens until an end token, junk everything and return the error.
 
-skip_tokens(Ics, Line, Error)                           ->
-    skip_tokens(Ics, Line, yystate(), Ics, 0, Error, reject, 0).
+skip_tokens(Ics, Line, Error) ->
+    skip_tokens(yystate(), Ics, Line, Ics, 0, Line, Error, reject, 0).
 
-%% skip_tokens(InChars, Line, State, TokenChars, CurrTokLen, Tokens,
-%%             AcceptAction, AcceptLen) ->
-%%    {more,Continuation} | {done,ReturnVal,RestChars}.
+%% skip_tokens(State, InChars, Line, TokenChars, TokenLen, TokenLine, Tokens,
+%% AcceptAction, AcceptLen) ->
+%% {more,Continuation} | {done,ReturnVal,RestChars}.
 
-skip_tokens(Ics0, L0, S0, Tcs, Clen0, Error, A0, Alen0) ->
-    case yystate(S0, Ics0, L0, Clen0, A0, Alen0) of
-	{A1,Alen1,Ics1,L1} ->			%Accepting end state
-	    skip_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, L1), Error);
-	{A1,Alen1,[],L1,S1} ->			%After an accepting state
-	    {more,{skip_tokens,L1,S1,Tcs,Alen1,Error,A1,Alen1}};
-	{A1,Alen1,Ics1,L1,_S1} ->
-	    skip_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, L1), Error);
-	{A1,Alen1,Clen1,[],L1,S1} ->		%After a non-accepting state
-	    {more,{skip_tokens,L1,S1,Tcs,Clen1,Error,A1,Alen1}};
-	{reject,_Alen1,_Clen1,eof,L1,_S1} ->
-	    {done,{error,Error,L1},[]};
-	{reject,_Alen1,Clen1,_Ics1,L1,_S1} ->
-	    skip_tokens(yysuf(Tcs, Clen1+1), L1, Error);
-	{A1,Alen1,_Clen1,_Ics1,L1,_S1} ->
-	    skip_cont(yysuf(Tcs, Alen1), L1, yyaction(A1, Alen1, Tcs, L1), Error)
+skip_tokens(S0, Ics0, L0, Tcs, Tlen0, Tline, Error, A0, Alen0) ->
+    case yystate(S0, Ics0, L0, Tlen0, A0, Alen0) of
+        {A1,Alen1,Ics1,L1} ->                  % Accepting end state
+            skip_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline), Error);
+        {A1,Alen1,[],L1,S1} ->                 % After an accepting state
+            {more,{skip_tokens,S1,L1,Tcs,Alen1,Tline,Error,A1,Alen1}};
+        {A1,Alen1,Ics1,L1,_S1} ->
+            skip_cont(Ics1, L1, yyaction(A1, Alen1, Tcs, Tline), Error);
+        {A1,Alen1,Tlen1,[],L1,S1} ->           % After a non-accepting state
+            {more,{skip_tokens,S1,L1,Tcs,Tlen1,Tline,Error,A1,Alen1}};
+        {reject,_Alen1,_Tlen1,eof,L1,_S1} ->
+            {done,{error,Error,L1},eof};
+        {reject,_Alen1,Tlen1,_Ics1,L1,_S1} ->
+            skip_tokens(yysuf(Tcs, Tlen1+1), L1, Error);
+        {A1,Alen1,_Tlen1,_Ics1,L1,_S1} ->
+            Token = yyaction(A1, Alen1, Tcs, Tline),
+            skip_cont(yysuf(Tcs, Alen1), L1, Token, Error)
     end.
 
 %% skip_cont(RestChars, Line, Token, Error)
-%%  Skip tokens until we have an end_token or error then return done
-%%  with the original rror.
+%% Skip tokens until we have an end_token or error then return done
+%% with the original rror.
 
 skip_cont(Rest, Line, {token,_T}, Error) ->
-    skip_tokens(Rest, Line, yystate(), Rest, 0, Error, reject, 0);
+    skip_tokens(yystate(), Rest, Line, Rest, 0, Line, Error, reject, 0);
+skip_cont(Rest, Line, {token,_T,Push}, Error) ->
+    NewRest = Push ++ Rest,
+    skip_tokens(yystate(), NewRest, Line, NewRest, 0, Line, Error, reject, 0);
 skip_cont(Rest, Line, {end_token,_T}, Error) ->
     {done,{error,Error,Line},Rest};
-skip_cont(Rest, Line, {error,_S}, Error) ->
-    skip_tokens(Rest, Line, yystate(), Rest, 0, Error, reject, 0);
+skip_cont(Rest, Line, {end_token,_T,Push}, Error) ->
+    NewRest = Push ++ Rest,
+    {done,{error,Error,Line},NewRest};
 skip_cont(Rest, Line, skip_token, Error) ->
-    skip_tokens(Rest, Line, yystate(), Rest, 0, Error, reject, 0).
+    skip_tokens(yystate(), Rest, Line, Rest, 0, Line, Error, reject, 0);
+skip_cont(Rest, Line, {skip_token,Push}, Error) ->
+    NewRest = Push ++ Rest,
+    skip_tokens(yystate(), NewRest, Line, NewRest, 0, Line, Error, reject, 0);
+skip_cont(Rest, Line, {error,_S}, Error) ->
+    skip_tokens(yystate(), Rest, Line, Rest, 0, Line, Error, reject, 0).
 
 yyrev(List) -> lists:reverse(List).
 yyrev(List, Tail) -> lists:reverse(List, Tail).
@@ -235,221 +310,228 @@ yysuf(List, N) -> lists:nthtail(N, List).
 
 %% yystate() -> InitialState.
 %% yystate(State, InChars, Line, CurrTokLen, AcceptAction, AcceptLen) ->
-%%      {Action, AcceptLen, RestChars, Line} |
-%%      {Action, AcceptLen, RestChars, Line, State} |
-%%      {reject, AcceptLen, CurrTokLen, RestChars, Line, State} |
-%%      {Action, AcceptLen, CurrTokLen, RestChars, Line, State}.
+%% {Action, AcceptLen, RestChars, Line} |
+%% {Action, AcceptLen, RestChars, Line, State} |
+%% {reject, AcceptLen, CurrTokLen, RestChars, Line, State} |
+%% {Action, AcceptLen, CurrTokLen, RestChars, Line, State}.
 %% Generated state transition functions. The non-accepting end state
 %% return signal either an unrecognised character or end of current
 %% input.
 
+-file("./json_lex2.erl", 320).
 yystate() -> 32.
 
-yystate(35, [C|Ics], Line, Tlen, _, _) when C >= $0, C =< $9 ->
-    yystate(35, Ics, Line, Tlen+1, 5, Tlen);
 yystate(35, Ics, Line, Tlen, _, _) ->
-    {5,Tlen,Ics,Line,35};
+    {2,Tlen,Ics,Line};
+yystate(34, [37|Ics], Line, Tlen, _, _) ->
+    yystate(14, Ics, Line, Tlen+1, 13, Tlen);
+yystate(34, [10|Ics], Line, Tlen, _, _) ->
+    yystate(34, Ics, Line+1, Tlen+1, 13, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 0, C =< 9 ->
+    yystate(34, Ics, Line, Tlen+1, 13, Tlen);
+yystate(34, [C|Ics], Line, Tlen, _, _) when C >= 11, C =< 32 ->
+    yystate(34, Ics, Line, Tlen+1, 13, Tlen);
 yystate(34, Ics, Line, Tlen, _, _) ->
-    {1,Tlen,Ics,Line};
+    {13,Tlen,Ics,Line,34};
 yystate(33, Ics, Line, Tlen, _, _) ->
     {11,Tlen,Ics,Line};
-yystate(32, [$\n|Ics], Line, Tlen, Action, Alen) ->
-    yystate(28, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(32, [$"|Ics], Line, Tlen, Action, Alen) ->
+yystate(32, [125|Ics], Line, Tlen, Action, Alen) ->
+    yystate(28, Ics, Line, Tlen+1, Action, Alen);
+yystate(32, [123|Ics], Line, Tlen, Action, Alen) ->
     yystate(24, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [$%|Ics], Line, Tlen, Action, Alen) ->
-    yystate(8, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [$,|Ics], Line, Tlen, Action, Alen) ->
+yystate(32, [116|Ics], Line, Tlen, Action, Alen) ->
+    yystate(20, Ics, Line, Tlen+1, Action, Alen);
+yystate(32, [110|Ics], Line, Tlen, Action, Alen) ->
     yystate(4, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [$-|Ics], Line, Tlen, Action, Alen) ->
-    yystate(0, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [$:|Ics], Line, Tlen, Action, Alen) ->
+yystate(32, [102|Ics], Line, Tlen, Action, Alen) ->
+    yystate(11, Ics, Line, Tlen+1, Action, Alen);
+yystate(32, [93|Ics], Line, Tlen, Action, Alen) ->
+    yystate(31, Ics, Line, Tlen+1, Action, Alen);
+yystate(32, [91|Ics], Line, Tlen, Action, Alen) ->
+    yystate(35, Ics, Line, Tlen+1, Action, Alen);
+yystate(32, [58|Ics], Line, Tlen, Action, Alen) ->
     yystate(33, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [$[|Ics], Line, Tlen, Action, Alen) ->
-    yystate(29, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [$]|Ics], Line, Tlen, Action, Alen) ->
-    yystate(25, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [$f|Ics], Line, Tlen, Action, Alen) ->
-    yystate(21, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [$n|Ics], Line, Tlen, Action, Alen) ->
-    yystate(1, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [$t|Ics], Line, Tlen, Action, Alen) ->
+yystate(32, [45|Ics], Line, Tlen, Action, Alen) ->
+    yystate(6, Ics, Line, Tlen+1, Action, Alen);
+yystate(32, [44|Ics], Line, Tlen, Action, Alen) ->
+    yystate(10, Ics, Line, Tlen+1, Action, Alen);
+yystate(32, [37|Ics], Line, Tlen, Action, Alen) ->
     yystate(14, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [${|Ics], Line, Tlen, Action, Alen) ->
+yystate(32, [34|Ics], Line, Tlen, Action, Alen) ->
     yystate(30, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [$}|Ics], Line, Tlen, Action, Alen) ->
+yystate(32, [10|Ics], Line, Tlen, Action, Alen) ->
+    yystate(34, Ics, Line+1, Tlen+1, Action, Alen);
+yystate(32, [C|Ics], Line, Tlen, Action, Alen) when C >= 0, C =< 9 ->
     yystate(34, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [C|Ics], Line, Tlen, Action, Alen) when C >= $\000, C =< $\t ->
-    yystate(28, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [C|Ics], Line, Tlen, Action, Alen) when C >= $\v, C =< $\s ->
-    yystate(28, Ics, Line, Tlen+1, Action, Alen);
-yystate(32, [C|Ics], Line, Tlen, Action, Alen) when C >= $0, C =< $9 ->
-    yystate(3, Ics, Line, Tlen+1, Action, Alen);
+yystate(32, [C|Ics], Line, Tlen, Action, Alen) when C >= 11, C =< 32 ->
+    yystate(34, Ics, Line, Tlen+1, Action, Alen);
+yystate(32, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
 yystate(32, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,32};
-yystate(31, [C|Ics], Line, Tlen, Action, Alen) when C >= $0, C =< $9 ->
-    yystate(35, Ics, Line, Tlen+1, Action, Alen);
-yystate(31, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,31};
-yystate(30, Ics, Line, Tlen, _, _) ->
-    {0,Tlen,Ics,Line};
-yystate(29, Ics, Line, Tlen, _, _) ->
-    {2,Tlen,Ics,Line};
-yystate(28, [$\n|Ics], Line, Tlen, _, _) ->
-    yystate(28, Ics, Line+1, Tlen+1, 13, Tlen);
-yystate(28, [$%|Ics], Line, Tlen, _, _) ->
-    yystate(8, Ics, Line, Tlen+1, 13, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= $\000, C =< $\t ->
-    yystate(28, Ics, Line, Tlen+1, 13, Tlen);
-yystate(28, [C|Ics], Line, Tlen, _, _) when C >= $\v, C =< $\s ->
-    yystate(28, Ics, Line, Tlen+1, 13, Tlen);
-yystate(28, Ics, Line, Tlen, _, _) ->
-    {13,Tlen,Ics,Line,28};
-yystate(27, [$+|Ics], Line, Tlen, Action, Alen) ->
-    yystate(31, Ics, Line, Tlen+1, Action, Alen);
-yystate(27, [$-|Ics], Line, Tlen, Action, Alen) ->
-    yystate(31, Ics, Line, Tlen+1, Action, Alen);
-yystate(27, [C|Ics], Line, Tlen, Action, Alen) when C >= $0, C =< $9 ->
-    yystate(35, Ics, Line, Tlen+1, Action, Alen);
-yystate(27, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,27};
-yystate(26, Ics, Line, Tlen, _, _) ->
-    {8,Tlen,Ics,Line};
-yystate(25, Ics, Line, Tlen, _, _) ->
+yystate(31, Ics, Line, Tlen, _, _) ->
     {3,Tlen,Ics,Line};
-yystate(24, [$\n|Ics], Line, Tlen, Action, Alen) ->
-    yystate(24, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(24, [$"|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(24, [$\\|Ics], Line, Tlen, Action, Alen) ->
-    yystate(16, Ics, Line, Tlen+1, Action, Alen);
-yystate(24, [C|Ics], Line, Tlen, Action, Alen) when C >= $\000, C =< $\t ->
-    yystate(24, Ics, Line, Tlen+1, Action, Alen);
-yystate(24, [C|Ics], Line, Tlen, Action, Alen) when C >= $\v, C =< $! ->
-    yystate(24, Ics, Line, Tlen+1, Action, Alen);
-yystate(24, [C|Ics], Line, Tlen, Action, Alen) when C >= $#, C =< $[ ->
-    yystate(24, Ics, Line, Tlen+1, Action, Alen);
-yystate(24, [C|Ics], Line, Tlen, Action, Alen) when C >= $], C =< $ÿ ->
-    yystate(24, Ics, Line, Tlen+1, Action, Alen);
-yystate(24, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,24};
-yystate(23, [C|Ics], Line, Tlen, _, _) when C >= $0, C =< $9 ->
-    yystate(23, Ics, Line, Tlen+1, 4, Tlen);
-yystate(23, Ics, Line, Tlen, _, _) ->
-    {4,Tlen,Ics,Line,23};
-yystate(22, [$e|Ics], Line, Tlen, Action, Alen) ->
+yystate(30, [92|Ics], Line, Tlen, Action, Alen) ->
+    yystate(18, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, [34|Ics], Line, Tlen, Action, Alen) ->
     yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, [10|Ics], Line, Tlen, Action, Alen) ->
+    yystate(30, Ics, Line+1, Tlen+1, Action, Alen);
+yystate(30, [C|Ics], Line, Tlen, Action, Alen) when C >= 0, C =< 9 ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, [C|Ics], Line, Tlen, Action, Alen) when C >= 11, C =< 33 ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, [C|Ics], Line, Tlen, Action, Alen) when C >= 35, C =< 91 ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, [C|Ics], Line, Tlen, Action, Alen) when C >= 93 ->
+    yystate(30, Ics, Line, Tlen+1, Action, Alen);
+yystate(30, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,30};
+yystate(29, [101|Ics], Line, Tlen, _, _) ->
+    yystate(17, Ics, Line, Tlen+1, 6, Tlen);
+yystate(29, [69|Ics], Line, Tlen, _, _) ->
+    yystate(17, Ics, Line, Tlen+1, 6, Tlen);
+yystate(29, [46|Ics], Line, Tlen, _, _) ->
+    yystate(13, Ics, Line, Tlen+1, 6, Tlen);
+yystate(29, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(29, Ics, Line, Tlen+1, 6, Tlen);
+yystate(29, Ics, Line, Tlen, _, _) ->
+    {6,Tlen,Ics,Line,29};
+yystate(28, Ics, Line, Tlen, _, _) ->
+    {1,Tlen,Ics,Line};
+yystate(27, Ics, Line, Tlen, _, _) ->
+    {9,Tlen,Ics,Line};
+yystate(26, Ics, Line, Tlen, _, _) ->
+    {7,Tlen,Ics,Line};
+yystate(25, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(25, Ics, Line, Tlen+1, 5, Tlen);
+yystate(25, Ics, Line, Tlen, _, _) ->
+    {5,Tlen,Ics,Line,25};
+yystate(24, Ics, Line, Tlen, _, _) ->
+    {0,Tlen,Ics,Line};
+yystate(23, [101|Ics], Line, Tlen, Action, Alen) ->
+    yystate(27, Ics, Line, Tlen+1, Action, Alen);
+yystate(23, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,23};
+yystate(22, [92|Ics], Line, Tlen, Action, Alen) ->
+    yystate(18, Ics, Line, Tlen+1, Action, Alen);
+yystate(22, [34|Ics], Line, Tlen, Action, Alen) ->
+    yystate(26, Ics, Line, Tlen+1, Action, Alen);
+yystate(22, [10|Ics], Line, Tlen, Action, Alen) ->
+    yystate(22, Ics, Line+1, Tlen+1, Action, Alen);
+yystate(22, [C|Ics], Line, Tlen, Action, Alen) when C >= 0, C =< 9 ->
+    yystate(22, Ics, Line, Tlen+1, Action, Alen);
+yystate(22, [C|Ics], Line, Tlen, Action, Alen) when C >= 11, C =< 33 ->
+    yystate(22, Ics, Line, Tlen+1, Action, Alen);
+yystate(22, [C|Ics], Line, Tlen, Action, Alen) when C >= 35, C =< 91 ->
+    yystate(22, Ics, Line, Tlen+1, Action, Alen);
+yystate(22, [C|Ics], Line, Tlen, Action, Alen) when C >= 93 ->
+    yystate(22, Ics, Line, Tlen+1, Action, Alen);
 yystate(22, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,22};
-yystate(21, [$a|Ics], Line, Tlen, Action, Alen) ->
-    yystate(17, Ics, Line, Tlen+1, Action, Alen);
+yystate(21, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(25, Ics, Line, Tlen+1, Action, Alen);
 yystate(21, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,21};
-yystate(20, Ics, Line, Tlen, _, _) ->
-    {7,Tlen,Ics,Line};
-yystate(19, [C|Ics], Line, Tlen, Action, Alen) when C >= $0, C =< $9 ->
+yystate(20, [114|Ics], Line, Tlen, Action, Alen) ->
+    yystate(16, Ics, Line, Tlen+1, Action, Alen);
+yystate(20, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,20};
+yystate(19, [115|Ics], Line, Tlen, Action, Alen) ->
     yystate(23, Ics, Line, Tlen+1, Action, Alen);
 yystate(19, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,19};
-yystate(18, [$u|Ics], Line, Tlen, Action, Alen) ->
+yystate(18, [C|Ics], Line, Tlen, Action, Alen) when C >= 0, C =< 9 ->
+    yystate(22, Ics, Line, Tlen+1, Action, Alen);
+yystate(18, [C|Ics], Line, Tlen, Action, Alen) when C >= 11 ->
     yystate(22, Ics, Line, Tlen+1, Action, Alen);
 yystate(18, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,18};
-yystate(17, [$l|Ics], Line, Tlen, Action, Alen) ->
-    yystate(13, Ics, Line, Tlen+1, Action, Alen);
+yystate(17, [45|Ics], Line, Tlen, Action, Alen) ->
+    yystate(21, Ics, Line, Tlen+1, Action, Alen);
+yystate(17, [43|Ics], Line, Tlen, Action, Alen) ->
+    yystate(21, Ics, Line, Tlen+1, Action, Alen);
+yystate(17, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(25, Ics, Line, Tlen+1, Action, Alen);
 yystate(17, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,17};
-yystate(16, [C|Ics], Line, Tlen, Action, Alen) when C >= $\000, C =< $\t ->
-    yystate(12, Ics, Line, Tlen+1, Action, Alen);
-yystate(16, [C|Ics], Line, Tlen, Action, Alen) when C >= $\v, C =< $ÿ ->
+yystate(16, [117|Ics], Line, Tlen, Action, Alen) ->
     yystate(12, Ics, Line, Tlen+1, Action, Alen);
 yystate(16, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,16};
-yystate(15, [$+|Ics], Line, Tlen, Action, Alen) ->
+yystate(15, [108|Ics], Line, Tlen, Action, Alen) ->
     yystate(19, Ics, Line, Tlen+1, Action, Alen);
-yystate(15, [$-|Ics], Line, Tlen, Action, Alen) ->
-    yystate(19, Ics, Line, Tlen+1, Action, Alen);
-yystate(15, [C|Ics], Line, Tlen, Action, Alen) when C >= $0, C =< $9 ->
-    yystate(23, Ics, Line, Tlen+1, Action, Alen);
 yystate(15, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,15};
-yystate(14, [$r|Ics], Line, Tlen, Action, Alen) ->
-    yystate(18, Ics, Line, Tlen+1, Action, Alen);
-yystate(14, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,14};
-yystate(13, [$s|Ics], Line, Tlen, Action, Alen) ->
+yystate(14, [37|Ics], Line, Tlen, _, _) ->
+    yystate(14, Ics, Line, Tlen+1, 13, Tlen);
+yystate(14, [10|Ics], Line, Tlen, _, _) ->
+    yystate(34, Ics, Line+1, Tlen+1, 13, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 0, C =< 9 ->
+    yystate(14, Ics, Line, Tlen+1, 13, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 11, C =< 32 ->
+    yystate(14, Ics, Line, Tlen+1, 13, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 33, C =< 36 ->
+    yystate(14, Ics, Line, Tlen+1, 13, Tlen);
+yystate(14, [C|Ics], Line, Tlen, _, _) when C >= 38 ->
+    yystate(14, Ics, Line, Tlen+1, 13, Tlen);
+yystate(14, Ics, Line, Tlen, _, _) ->
+    {13,Tlen,Ics,Line,14};
+yystate(13, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
     yystate(9, Ics, Line, Tlen+1, Action, Alen);
 yystate(13, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,13};
-yystate(12, [$\n|Ics], Line, Tlen, Action, Alen) ->
-    yystate(12, Ics, Line+1, Tlen+1, Action, Alen);
-yystate(12, [$"|Ics], Line, Tlen, Action, Alen) ->
-    yystate(20, Ics, Line, Tlen+1, Action, Alen);
-yystate(12, [$\\|Ics], Line, Tlen, Action, Alen) ->
-    yystate(16, Ics, Line, Tlen+1, Action, Alen);
-yystate(12, [C|Ics], Line, Tlen, Action, Alen) when C >= $\000, C =< $\t ->
-    yystate(12, Ics, Line, Tlen+1, Action, Alen);
-yystate(12, [C|Ics], Line, Tlen, Action, Alen) when C >= $\v, C =< $! ->
-    yystate(12, Ics, Line, Tlen+1, Action, Alen);
-yystate(12, [C|Ics], Line, Tlen, Action, Alen) when C >= $#, C =< $[ ->
-    yystate(12, Ics, Line, Tlen+1, Action, Alen);
-yystate(12, [C|Ics], Line, Tlen, Action, Alen) when C >= $], C =< $ÿ ->
-    yystate(12, Ics, Line, Tlen+1, Action, Alen);
+yystate(12, [101|Ics], Line, Tlen, Action, Alen) ->
+    yystate(8, Ics, Line, Tlen+1, Action, Alen);
 yystate(12, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,12};
-yystate(11, [$E|Ics], Line, Tlen, _, _) ->
-    yystate(15, Ics, Line, Tlen+1, 4, Tlen);
-yystate(11, [$e|Ics], Line, Tlen, _, _) ->
-    yystate(15, Ics, Line, Tlen+1, 4, Tlen);
-yystate(11, [C|Ics], Line, Tlen, _, _) when C >= $0, C =< $9 ->
-    yystate(11, Ics, Line, Tlen+1, 4, Tlen);
-yystate(11, Ics, Line, Tlen, _, _) ->
-    {4,Tlen,Ics,Line,11};
+yystate(11, [97|Ics], Line, Tlen, Action, Alen) ->
+    yystate(15, Ics, Line, Tlen+1, Action, Alen);
+yystate(11, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,11};
 yystate(10, Ics, Line, Tlen, _, _) ->
-    {10,Tlen,Ics,Line};
-yystate(9, [$e|Ics], Line, Tlen, Action, Alen) ->
-    yystate(5, Ics, Line, Tlen+1, Action, Alen);
-yystate(9, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,9};
-yystate(8, [$\n|Ics], Line, Tlen, _, _) ->
-    yystate(28, Ics, Line+1, Tlen+1, 13, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= $\000, C =< $\t ->
-    yystate(8, Ics, Line, Tlen+1, 13, Tlen);
-yystate(8, [C|Ics], Line, Tlen, _, _) when C >= $\v, C =< $ÿ ->
-    yystate(8, Ics, Line, Tlen+1, 13, Tlen);
+    {12,Tlen,Ics,Line};
+yystate(9, [101|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 4, Tlen);
+yystate(9, [69|Ics], Line, Tlen, _, _) ->
+    yystate(2, Ics, Line, Tlen+1, 4, Tlen);
+yystate(9, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(9, Ics, Line, Tlen+1, 4, Tlen);
+yystate(9, Ics, Line, Tlen, _, _) ->
+    {4,Tlen,Ics,Line,9};
 yystate(8, Ics, Line, Tlen, _, _) ->
-    {13,Tlen,Ics,Line,8};
-yystate(7, [C|Ics], Line, Tlen, Action, Alen) when C >= $0, C =< $9 ->
-    yystate(11, Ics, Line, Tlen+1, Action, Alen);
-yystate(7, Ics, Line, Tlen, Action, Alen) ->
-    {Action,Alen,Tlen,Ics,Line,7};
-yystate(6, [$l|Ics], Line, Tlen, Action, Alen) ->
-    yystate(10, Ics, Line, Tlen+1, Action, Alen);
+    {8,Tlen,Ics,Line};
+yystate(7, Ics, Line, Tlen, _, _) ->
+    {10,Tlen,Ics,Line};
+yystate(6, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(29, Ics, Line, Tlen+1, Action, Alen);
 yystate(6, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,6};
+yystate(5, [C|Ics], Line, Tlen, _, _) when C >= 48, C =< 57 ->
+    yystate(5, Ics, Line, Tlen+1, 4, Tlen);
 yystate(5, Ics, Line, Tlen, _, _) ->
-    {9,Tlen,Ics,Line};
-yystate(4, Ics, Line, Tlen, _, _) ->
-    {12,Tlen,Ics,Line};
-yystate(3, [$.|Ics], Line, Tlen, _, _) ->
-    yystate(7, Ics, Line, Tlen+1, 6, Tlen);
-yystate(3, [$E|Ics], Line, Tlen, _, _) ->
-    yystate(27, Ics, Line, Tlen+1, 6, Tlen);
-yystate(3, [$e|Ics], Line, Tlen, _, _) ->
-    yystate(27, Ics, Line, Tlen+1, 6, Tlen);
-yystate(3, [C|Ics], Line, Tlen, _, _) when C >= $0, C =< $9 ->
-    yystate(3, Ics, Line, Tlen+1, 6, Tlen);
-yystate(3, Ics, Line, Tlen, _, _) ->
-    {6,Tlen,Ics,Line,3};
-yystate(2, [$l|Ics], Line, Tlen, Action, Alen) ->
-    yystate(6, Ics, Line, Tlen+1, Action, Alen);
+    {4,Tlen,Ics,Line,5};
+yystate(4, [117|Ics], Line, Tlen, Action, Alen) ->
+    yystate(0, Ics, Line, Tlen+1, Action, Alen);
+yystate(4, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,4};
+yystate(3, [108|Ics], Line, Tlen, Action, Alen) ->
+    yystate(7, Ics, Line, Tlen+1, Action, Alen);
+yystate(3, Ics, Line, Tlen, Action, Alen) ->
+    {Action,Alen,Tlen,Ics,Line,3};
+yystate(2, [45|Ics], Line, Tlen, Action, Alen) ->
+    yystate(1, Ics, Line, Tlen+1, Action, Alen);
+yystate(2, [43|Ics], Line, Tlen, Action, Alen) ->
+    yystate(1, Ics, Line, Tlen+1, Action, Alen);
+yystate(2, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(5, Ics, Line, Tlen+1, Action, Alen);
 yystate(2, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,2};
-yystate(1, [$u|Ics], Line, Tlen, Action, Alen) ->
-    yystate(2, Ics, Line, Tlen+1, Action, Alen);
+yystate(1, [C|Ics], Line, Tlen, Action, Alen) when C >= 48, C =< 57 ->
+    yystate(5, Ics, Line, Tlen+1, Action, Alen);
 yystate(1, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,1};
-yystate(0, [C|Ics], Line, Tlen, Action, Alen) when C >= $0, C =< $9 ->
+yystate(0, [108|Ics], Line, Tlen, Action, Alen) ->
     yystate(3, Ics, Line, Tlen+1, Action, Alen);
 yystate(0, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,0};
@@ -457,39 +539,111 @@ yystate(S, Ics, Line, Tlen, Action, Alen) ->
     {Action,Alen,Tlen,Ics,Line,S}.
 
 %% yyaction(Action, TokenLength, TokenChars, TokenLine) ->
-%%        {token,Token} | {end_token, Token} | skip_token | {error,String}.
+%% {token,Token} | {end_token, Token} | skip_token | {error,String}.
 %% Generated action function.
 
 yyaction(0, _, _, TokenLine) ->
-    {token,{'{',TokenLine}};
+    yyaction_0(TokenLine);
 yyaction(1, _, _, TokenLine) ->
-    {token,{'}',TokenLine}};
+    yyaction_1(TokenLine);
 yyaction(2, _, _, TokenLine) ->
-    {token,{'[',TokenLine}};
+    yyaction_2(TokenLine);
 yyaction(3, _, _, TokenLine) ->
-    {token,{']',TokenLine}};
+    yyaction_3(TokenLine);
 yyaction(4, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    {token,{float,TokenLine,list_to_float(TokenChars)}};
+    yyaction_4(TokenChars, TokenLine);
 yyaction(5, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    {token,{float,TokenLine,whole_float(TokenChars)}};
+    yyaction_5(TokenChars, TokenLine);
 yyaction(6, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    {token,{integer,TokenLine,list_to_integer(TokenChars)}};
+    yyaction_6(TokenChars, TokenLine);
 yyaction(7, TokenLen, YYtcs, TokenLine) ->
     TokenChars = yypre(YYtcs, TokenLen),
-    {token,{string,TokenLine,parse_string(strip(TokenChars, TokenLen))}};
+    yyaction_7(TokenChars, TokenLen, TokenLine);
 yyaction(8, _, _, TokenLine) ->
-    {token,{true,TokenLine}};
+    yyaction_8(TokenLine);
 yyaction(9, _, _, TokenLine) ->
-    {token,{false,TokenLine}};
+    yyaction_9(TokenLine);
 yyaction(10, _, _, TokenLine) ->
-    {token,{null,TokenLine}};
+    yyaction_10(TokenLine);
 yyaction(11, _, _, TokenLine) ->
-    {token,{':',TokenLine}};
+    yyaction_11(TokenLine);
 yyaction(12, _, _, TokenLine) ->
-    {token,{',',TokenLine}};
+    yyaction_12(TokenLine);
 yyaction(13, _, _, _) ->
-    skip_token;
+    yyaction_13();
 yyaction(_, _, _, _) -> error.
+
+-compile({inline,yyaction_0/1}).
+-file("./json_lex2.xrl", 9).
+yyaction_0(TokenLine) ->
+     { token, { '{', TokenLine } } .
+
+-compile({inline,yyaction_1/1}).
+-file("./json_lex2.xrl", 10).
+yyaction_1(TokenLine) ->
+     { token, { '}', TokenLine } } .
+
+-compile({inline,yyaction_2/1}).
+-file("./json_lex2.xrl", 12).
+yyaction_2(TokenLine) ->
+     { token, { '[', TokenLine } } .
+
+-compile({inline,yyaction_3/1}).
+-file("./json_lex2.xrl", 13).
+yyaction_3(TokenLine) ->
+     { token, { ']', TokenLine } } .
+
+-compile({inline,yyaction_4/2}).
+-file("./json_lex2.xrl", 15).
+yyaction_4(TokenChars, TokenLine) ->
+     { token, { float, TokenLine, list_to_float (TokenChars) } } .
+
+-compile({inline,yyaction_5/2}).
+-file("./json_lex2.xrl", 16).
+yyaction_5(TokenChars, TokenLine) ->
+     { token, { float, TokenLine, whole_float (TokenChars) } } .
+
+-compile({inline,yyaction_6/2}).
+-file("./json_lex2.xrl", 17).
+yyaction_6(TokenChars, TokenLine) ->
+     { token, { integer, TokenLine, list_to_integer (TokenChars) } } .
+
+-compile({inline,yyaction_7/3}).
+-file("./json_lex2.xrl", 19).
+yyaction_7(TokenChars, TokenLen, TokenLine) ->
+     { token, { string, TokenLine, parse_string (strip (TokenChars, TokenLen)) } } .
+
+-compile({inline,yyaction_8/1}).
+-file("./json_lex2.xrl", 21).
+yyaction_8(TokenLine) ->
+     { token, { true, TokenLine } } .
+
+-compile({inline,yyaction_9/1}).
+-file("./json_lex2.xrl", 22).
+yyaction_9(TokenLine) ->
+     { token, { false, TokenLine } } .
+
+-compile({inline,yyaction_10/1}).
+-file("./json_lex2.xrl", 23).
+yyaction_10(TokenLine) ->
+     { token, { null, TokenLine } } .
+
+-compile({inline,yyaction_11/1}).
+-file("./json_lex2.xrl", 25).
+yyaction_11(TokenLine) ->
+     { token, { ':', TokenLine } } .
+
+-compile({inline,yyaction_12/1}).
+-file("./json_lex2.xrl", 26).
+yyaction_12(TokenLine) ->
+     { token, { ',', TokenLine } } .
+
+-compile({inline,yyaction_13/0}).
+-file("./json_lex2.xrl", 28).
+yyaction_13() ->
+     skip_token .
+
+-file("/usr/local/lib/erlang/lib/parsetools-2.0.9/include/leexinc.hrl", 282).

--- a/json_lex2.xrl
+++ b/json_lex2.xrl
@@ -59,7 +59,12 @@ unescape([$\\,$u,C0,C1,C2,C3|Cs]) ->
 	(dehex(C2) bsl 4) bor
 	(dehex(C1) bsl 8) bor
 	(dehex(C0) bsl 12),
-    [C|unescape(Cs)];
+    case C > 255 of
+        true ->
+            [$\\, $u, C0, C1, C2, C3 |unescape(Cs)];
+        false ->
+            [C|unescape(Cs)]
+    end;
 unescape([C|Cs]) -> [C|unescape(Cs)];
 unescape([]) -> [].
 


### PR DESCRIPTION
The json parser had explicit unescaping for unicode characters, which was fine only for characters which fit in UTF8. All of the json passes through erlang:list_to_binary/1, which will error out with badarg when it encounters u0100 or higher (http://www.erlang.org/doc/apps/stdlib/unicode_usage.html#id60884). 

PR consists of 54f798b containing the "re-escape u0100 and higher" functionality + test, and d91c0ee which is the output of leex on my machine (parsetools 2.0.9). 
